### PR TITLE
Update plugin.json 避免以后的更新报错

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "siyuan-wiki-to-ref",
+  "name": "siyuan-href-to-ref",
   "author": "养恐龙",
   "url": "https://github.com/hqweay/siyuan-href-to-ref",
   "version": "0.1.2",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "siyuan-wiki-to-ref",
   "author": "养恐龙",
-  "url": "https://github.com/hqweay/siyuan-wiki-to-ref",
+  "url": "https://github.com/hqweay/siyuan-href-to-ref",
   "version": "0.1.2",
   "minAppVersion": "3.0.0",
   "backends": [


### PR DESCRIPTION
可能是仓库链接不对，导致一键更新全部插件的时候报错：

![image](https://github.com/hqweay/siyuan-href-to-ref/assets/78434827/0809984f-808e-47ac-bb76-7fd42f97eff5)

![image](https://github.com/hqweay/siyuan-href-to-ref/assets/78434827/276c568b-bdea-4f93-bec6-ef2294e5fbee)

~~name 字段是改不了了，所以只改仓库链接~~ 反正现在用户少，name 也改了吧

---

合并 PR 的时候记得再改 version 字段版本号，然后打包新版